### PR TITLE
refactor renderers to use nearby state

### DIFF
--- a/src/rendering/character.ts
+++ b/src/rendering/character.ts
@@ -1,9 +1,17 @@
-import { type CharacterMapInfo, Direction, Gender, SitState } from 'eolib';
+import {
+  type CharacterMapInfo,
+  Direction,
+  Gender,
+  SitState,
+} from 'eolib';
 import { GAME_WIDTH, HALF_GAME_HEIGHT, HALF_GAME_WIDTH } from '../game-state';
 import { GfxType, getBitmapById } from '../gfx';
 import { isoToScreen } from '../utils/iso-to-screen';
 import type { Vector2 } from '../vector';
 import { WALK_HEIGHT_FACTOR, WALK_TICKS, WALK_WIDTH_FACTOR } from '../consts';
+import { getPrevCoords } from '../utils/get-prev-coords';
+import { bigCoordsToCoords } from '../utils/big-coords-to-coords';
+import type { Client } from '../client';
 
 export enum CharacterState {
   Standing = 0,
@@ -25,19 +33,26 @@ const WALK_ANIMATION_FRAMES = 4;
 
 export class CharacterRenderer {
   isPlayer = false;
-  mapInfo: CharacterMapInfo;
+  playerId: number;
+  private client: Client;
   state: CharacterState = CharacterState.Standing;
   animationFrame = 0;
   walkOffset: Vector2 = { x: 0, y: 0 };
   walkTicks = WALK_TICKS;
 
-  constructor(mapInfo: CharacterMapInfo) {
-    this.mapInfo = mapInfo;
+  constructor(client: Client, playerId: number) {
+    this.client = client;
+    this.playerId = playerId;
+    const info = this.mapInfo;
     this.state =
-      mapInfo.sitState === SitState.Floor
+      info && info.sitState === SitState.Floor
         ? CharacterState.SitGround
         : CharacterState.Standing;
     this.preloadSprites();
+  }
+
+  get mapInfo(): CharacterMapInfo | undefined {
+    return this.client.nearby.characters.find((c) => c.playerId === this.playerId);
   }
 
   preloadSprites() {
@@ -54,9 +69,13 @@ export class CharacterRenderer {
   }
 
   tick() {
+    const info = this.mapInfo;
+    if (!info) return;
+
     if (this.state === CharacterState.Walking) {
       const walkFrame = Math.abs(this.walkTicks - WALK_TICKS) + 1;
       this.animationFrame = (this.animationFrame + 1) % WALK_ANIMATION_FRAMES;
+      const dir = info.direction;
       this.walkOffset = {
         [Direction.Up]: {
           x: WALK_WIDTH_FACTOR * walkFrame,
@@ -74,77 +93,67 @@ export class CharacterRenderer {
           x: WALK_WIDTH_FACTOR * walkFrame,
           y: WALK_HEIGHT_FACTOR * walkFrame,
         },
-      }[this.mapInfo.direction];
+      }[dir];
 
       this.walkTicks = Math.max(this.walkTicks - 1, 0);
       if (this.walkTicks === 0) {
-        const pos = this.mapInfo.coords;
-        switch (this.mapInfo.direction) {
-          case Direction.Up:
-            pos.y -= 1;
-            break;
-          case Direction.Down:
-            pos.y += 1;
-            break;
-          case Direction.Left:
-            pos.x -= 1;
-            break;
-          case Direction.Right:
-            pos.x += 1;
-            break;
-        }
-
         this.walkOffset = { x: 0, y: 0 };
         this.walkTicks = WALK_TICKS;
         this.setState(CharacterState.Standing);
       }
     }
 
-    if (
-      this.state === CharacterState.Standing &&
-      this.mapInfo.sitState === SitState.Floor
-    ) {
+    if (this.state === CharacterState.Standing && info.sitState === SitState.Floor) {
       this.setState(CharacterState.SitGround);
     }
 
-    if (
-      this.state === CharacterState.SitGround &&
-      this.mapInfo.sitState === SitState.Stand
-    ) {
+    if (this.state === CharacterState.SitGround && info.sitState === SitState.Stand) {
       this.setState(CharacterState.Standing);
     }
   }
 
-  render(ctx: CanvasRenderingContext2D, playerScreen: Vector2) {
+  render(
+    ctx: CanvasRenderingContext2D,
+    playerScreen: Vector2,
+    mapWidth: number,
+    mapHeight: number,
+  ) {
+    const info = this.mapInfo;
+    if (!info) return;
+
     switch (this.state) {
       case CharacterState.Standing:
-        this.renderStanding(ctx, playerScreen);
+        this.renderStanding(info, ctx, playerScreen);
         break;
       case CharacterState.Walking:
-        this.renderWalking(ctx, playerScreen);
+        this.renderWalking(info, ctx, playerScreen, mapWidth, mapHeight);
         break;
       case CharacterState.SitGround:
-        this.renderSittingOnGround(ctx, playerScreen);
+        this.renderSittingOnGround(info, ctx, playerScreen);
         break;
     }
   }
 
-  renderStanding(ctx: CanvasRenderingContext2D, playerScreen: Vector2) {
+  renderStanding(
+    info: CharacterMapInfo,
+    ctx: CanvasRenderingContext2D,
+    playerScreen: Vector2,
+  ) {
     const bmp = getBitmapById(GfxType.SkinSprites, 1);
     if (!bmp) {
       return;
     }
 
     const startX =
-      this.mapInfo.gender === Gender.Female ? 0 : CHARACTER_WIDTH * 2;
+      info.gender === Gender.Female ? 0 : CHARACTER_WIDTH * 2;
     const sourceX =
       startX +
-      ([Direction.Up, Direction.Left].includes(this.mapInfo.direction)
+      ([Direction.Up, Direction.Left].includes(info.direction)
         ? CHARACTER_WIDTH
         : 0);
-    const sourceY = this.mapInfo.skin * CHARACTER_HEIGHT;
+    const sourceY = info.skin * CHARACTER_HEIGHT;
 
-    const screenCoords = isoToScreen(this.mapInfo.coords);
+    const screenCoords = isoToScreen(info.coords);
 
     const screenX =
       screenCoords.x - HALF_CHARACTER_WIDTH - playerScreen.x + HALF_GAME_WIDTH;
@@ -153,7 +162,7 @@ export class CharacterRenderer {
       screenCoords.y - CHARACTER_HEIGHT - playerScreen.y + HALF_GAME_HEIGHT + 4;
 
     const mirrored = [Direction.Right, Direction.Up].includes(
-      this.mapInfo.direction,
+      info.direction,
     );
 
     if (mirrored) {
@@ -181,27 +190,31 @@ export class CharacterRenderer {
     }
   }
 
-  renderSittingOnGround(ctx: CanvasRenderingContext2D, playerScreen: Vector2) {
+  renderSittingOnGround(
+    info: CharacterMapInfo,
+    ctx: CanvasRenderingContext2D,
+    playerScreen: Vector2,
+  ) {
     const bmp = getBitmapById(GfxType.SkinSprites, 6);
     if (!bmp) {
       return;
     }
 
     const startX =
-      this.mapInfo.gender === Gender.Female
+      info.gender === Gender.Female
         ? 0
         : CHARACTER_SIT_GROUND_WIDTH * 2;
     const sourceX =
       startX +
-      ([Direction.Up, Direction.Left].includes(this.mapInfo.direction)
+      ([Direction.Up, Direction.Left].includes(info.direction)
         ? CHARACTER_SIT_GROUND_WIDTH
         : 0);
-    const sourceY = this.mapInfo.skin * CHARACTER_SIT_GROUND_HEIGHT;
+    const sourceY = info.skin * CHARACTER_SIT_GROUND_HEIGHT;
 
-    const screenCoords = isoToScreen(this.mapInfo.coords);
+    const screenCoords = isoToScreen(info.coords);
 
     const additionalOffset = { x: 0, y: 0 };
-    switch (this.mapInfo.direction) {
+    switch (info.direction) {
       case Direction.Up:
         additionalOffset.x = 2;
         additionalOffset.y = 11;
@@ -235,7 +248,7 @@ export class CharacterRenderer {
       additionalOffset.y;
 
     const mirrored = [Direction.Right, Direction.Up].includes(
-      this.mapInfo.direction,
+      info.direction,
     );
 
     if (mirrored) {
@@ -265,34 +278,43 @@ export class CharacterRenderer {
     }
   }
 
-  renderWalking(ctx: CanvasRenderingContext2D, playerScreen: Vector2) {
+  renderWalking(
+    info: CharacterMapInfo,
+    ctx: CanvasRenderingContext2D,
+    playerScreen: Vector2,
+    mapWidth: number,
+    mapHeight: number,
+  ) {
     const bmp = getBitmapById(GfxType.SkinSprites, 2);
     if (!bmp) {
       return;
     }
 
     const startX =
-      this.mapInfo.gender === Gender.Female ? 0 : CHARACTER_WALKING_WIDTH * 8;
+      info.gender === Gender.Female ? 0 : CHARACTER_WALKING_WIDTH * 8;
 
     if (this.state === CharacterState.Walking) {
-      console.log(
-        `Character: ${this.mapInfo.name} frame: ${this.animationFrame}`,
-      );
+      console.log(`Character: ${info.name} frame: ${this.animationFrame}`);
     }
 
     const sourceX =
       startX +
-      ([Direction.Up, Direction.Left].includes(this.mapInfo.direction)
+      ([Direction.Up, Direction.Left].includes(info.direction)
         ? CHARACTER_WALKING_WIDTH * WALK_ANIMATION_FRAMES
         : 0) +
       CHARACTER_WALKING_WIDTH * this.animationFrame;
-    const sourceY = this.mapInfo.skin * CHARACTER_WALKING_HEIGHT;
-
-    const screenCoords = isoToScreen(this.mapInfo.coords);
+    const sourceY = info.skin * CHARACTER_WALKING_HEIGHT;
+    const prevCoords = getPrevCoords(
+      bigCoordsToCoords(info.coords),
+      info.direction,
+      mapWidth,
+      mapHeight,
+    );
+    const screenCoords = isoToScreen(prevCoords);
 
     const additionalOffset = { x: 0, y: 0 };
-    if (this.mapInfo.gender === Gender.Female) {
-      switch (this.mapInfo.direction) {
+    if (info.gender === Gender.Female) {
+      switch (info.direction) {
         case Direction.Up:
           additionalOffset.x = 0;
           additionalOffset.y = 6;
@@ -311,7 +333,7 @@ export class CharacterRenderer {
           break;
       }
     } else {
-      switch (this.mapInfo.direction) {
+      switch (info.direction) {
         case Direction.Up:
           additionalOffset.x = 0;
           additionalOffset.y = 6;
@@ -348,7 +370,7 @@ export class CharacterRenderer {
       additionalOffset.y;
 
     const mirrored = [Direction.Right, Direction.Up].includes(
-      this.mapInfo.direction,
+      info.direction,
     );
 
     if (mirrored) {


### PR DESCRIPTION
## Summary
- reference map info from the Client's nearby state instead of storing copies in renderers
- derive walking start coordinates when rendering characters
- clean up imports for client types

## Testing
- `npm run build` *(fails: Cannot find module 'eolib' etc.)*
- `npx biome check .` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685174a14f648329a53d01de5039f5cb